### PR TITLE
Change shops with BG country code to BE

### DIFF
--- a/src/vendorData.json
+++ b/src/vendorData.json
@@ -407,7 +407,7 @@
   {
     "name": "Keeb Studio",
     "url": "https://www.keeb.studio",
-    "country": "bg",
+    "country": "be",
     "region": "europe"
   },
   {
@@ -694,7 +694,7 @@
   {
     "name": "MyKeyboard",
     "url": "https://www.mykeyboard.eu",
-    "country": "bg",
+    "country": "be",
     "region": "europe"
   },
   {
@@ -876,7 +876,7 @@
   {
     "name": "Salvun",
     "url": "https://www.salvun.com",
-    "country": "bg",
+    "country": "be",
     "region": "europe"
   },
   {


### PR DESCRIPTION
The country code for the vendors in Belgium is currently incorrect. The country code BG belongs to Bulgaria, Belgium is BE (https://www.iso.org/obp/ui/#iso:code:3166:BE)